### PR TITLE
ry/block-rotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test :
 OBJ = $(BUILD_DIR)/main.o \
 	  $(BUILD_DIR)/utils.o $(BUILD_DIR)/renderer.o \
 	  $(BUILD_DIR)/block_factory.o $(BUILD_DIR)/controller.o \
-	  $(BUILD_DIR)/scorer.o
+	  $(BUILD_DIR)/scorer.o $(BUILD_DIR)/rotate.o
 
 # ==== Make rules ====
 
@@ -90,4 +90,3 @@ $(BUILD_DIR)/%.o : $(SRC_DIR)/%.cpp $(SRC_DIR)/%.h
 # Builds c files in src/
 $(BUILD_DIR)/%.o : $(SRC_DIR)/%.c $(SRC_DIR)/%.h $(DEP_HEADERS)
 	$(C) -c $< -o $@ $(CFLAGS)
-

--- a/src/controller.c
+++ b/src/controller.c
@@ -47,16 +47,16 @@ void act_on_user_input(char user_input, State* s,
             *frame_counter += frames_until_next_move;
             break;
         case LEFT_KEY: // move block left
-            move_block(s, -1);
+            move_block(s, -1, NO_ROTATE);
             break;
         case RIGHT_KEY: // move block right
-            move_block(s, 1);
+            move_block(s, 1, NO_ROTATE);
             break;
         case ROTATE_CW_KEY: // rotate block clockwise
-            // TODO: @skelly rotate block clockwise
+            move_block(s, 0, RIGHT);
             break;
         case ROTATE_CCW_KEY: // rotate block counter-clockwise
-            // TODO: @skelly rotate block counter-clockwise
+            move_block(s, 0, LEFT);
             break;
         case PAUSE_KEY: // pause the game
             // TODO: @skelly pause the game
@@ -80,7 +80,7 @@ int is_within_grid(int x, int delta_x) {
     return 0;
 }
 
-int move_block(State* s, int delta_x) {
+int move_block(State* s, int delta_x, Rotation r) {
     // Clear cells occupied by the block
     for (int i = 0; i < 4; i++) {
         int x = s->block->cells[i][0] + s->block->x;
@@ -96,6 +96,13 @@ int move_block(State* s, int delta_x) {
 
     // Check for collision with other blocks and sides of stage
     if (canMove) {
+
+        // Check for block rotation
+        switch (r) {
+            case 1: break;
+            case 0: rotate_left(s->block); break; // rotate COUNTER-CLOCKWISE
+            case 2: rotate_right(s->block); break; // rotate CLOCKWISE
+        }
 
         // Resolve lateral movement before checking vertical movement
         for (int i = 0; i < 4; i++) {
@@ -151,7 +158,7 @@ void begin_game(State* s) {
 
         // Piece movement
         if (frameCounter >= MOVE_RATE) {
-            if (!move_block(s, 0)) {
+            if (!move_block(s, 0, NO_ROTATE)) {
                 // Block has hit the bottom of stage or top of another block.
                 // No longer meaningful to keep track of the
                 // block. Spawn a new block

--- a/src/controller.h
+++ b/src/controller.h
@@ -13,6 +13,7 @@
 #include "renderer.h"
 #include "block_factory.h"
 #include "scorer.h"
+#include "rotate.h"
 
 #define US 1000000 // 1 million microseconds per second
 #define TICK_RATE 60 // Steps per second
@@ -59,9 +60,8 @@ int is_within_grid(int x, int delta_x);
  * @returns 0 if the block was blocked from moving vertically, indicating that
  * the block has "settled" and will no longer be interactive
 */
-int move_block(State* state, int delta_x);
+int move_block(State* state, int delta_x, Rotation r);
 
 void begin_game(State* state);
 
 #endif
-

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include "renderer.h"
 #include "block_factory.h"
 #include "controller.h"
+#include "rotate.h"
 
 // Create grid and initialize all cells to zero (empty)
 void initialize_grid(int grid[GRID_W][GRID_H]) {
@@ -36,4 +37,3 @@ int main(int argc, char** argv) {
     set_up_screen();
     begin_game(state);
 }
-

--- a/src/rotate.c
+++ b/src/rotate.c
@@ -1,0 +1,32 @@
+#include "rotate.h"
+
+void rotate_block(Block* b, const int rotation_matrix[2][2]){
+    int rotated_cells[4][2], sum;
+
+    for (int i = 0; i < 4; i++) {     //row of first matrix
+        for (int j = 0; j < 2; j++) {   //column of second matrix
+            sum = 0;
+            for (int k = 0; k < 2; k++) {
+                sum += (b->cells[i][k]) * rotation_matrix[k][j];
+                rotated_cells[i][j]=sum;
+            }
+        }
+    };
+
+    // reassign block's cells to the rotated coordinates
+    memcpy(b->cells, rotated_cells, sizeof(b->cells));
+};
+
+void rotate_right(Block* b){
+    if (b->type == O) {
+        return;
+    }
+    rotate_block(b, rotation_matrix_R);
+};
+
+void rotate_left(Block* b){
+    if (b->type == O) {
+        return;
+    }
+    rotate_block(b, rotation_matrix_L);
+};

--- a/src/rotate.h
+++ b/src/rotate.h
@@ -1,0 +1,19 @@
+#ifndef ROTATE_H
+#define ROTATE_H
+
+#include <string.h>
+#include "utils.h"
+
+/* Rotates block 90 degrees
+using matrix multiplication with rotation matrix.*/
+void rotate_block(Block* b, const int rotation_matrix[2][2]);
+
+/* Rotates block 90 degrees CLOCKWISE.
+Checks block type for exception rotation cases. */
+void rotate_right(Block* b);
+
+/* Rotates block 90 degrees COUNTER-CLOCKWISE.
+Checks block type for exception rotation cases. */
+void rotate_left(Block *b);
+
+#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,3 +8,5 @@ const int ZBlock[4][2] = {{0,0}, {1,0}, {0,-1}, {-1,-1}};
 const int SBlock[4][2] = {{0,0}, {-1,0}, {0,-1}, {1,-1}};
 const int JBlock[4][2] = {{0,0}, {1,0}, {-1,0}, {-1,-1}};
 const int LBlock[4][2] = {{0,0}, {-1,0}, {1,0}, {1,-1}};
+const int rotation_matrix_R[2][2] = {{0,-1}, {1,0}};
+const int rotation_matrix_L[2][2] = {{0,1}, {-1,0}};

--- a/src/utils.h
+++ b/src/utils.h
@@ -30,6 +30,8 @@ extern const int ZBlock[4][2];
 extern const int SBlock[4][2];
 extern const int JBlock[4][2];
 extern const int LBlock[4][2];
+extern const int rotation_matrix_R[2][2];
+extern const int rotation_matrix_L[2][2];
 
 /*
  * Taken from https://i.stack.imgur.com/JLRFu.png
@@ -42,6 +44,11 @@ typedef enum {Empty, Cyan, Blue, White, Yellow, Green, Purple, Red} BlockColor;
  * Taken from http://tetris.wikia.com/wiki/Tetromino
  */
 typedef enum {I, O, T, Z, S, J, L} BlockType;
+
+/*
+ * Define rotation parameter
+ */
+typedef enum {LEFT, NO_ROTATE, RIGHT} Rotation;
 
 /*
   Representation of generic Tetris block


### PR DESCRIPTION
integrated keypress and rotation so that "f" rotates block clockwise and "d" rotates block counter-clockwise.
had to add parameter to move_block in controller.c for rotation parameter so that grid would clear properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thecardkid/softsysbombassticbamboo/14)
<!-- Reviewable:end -->
