### PR TITLE
FIX: compiler warnings, capitalised BlockColor enum, whitespaces

### DIFF
--- a/src/block_factory.c
+++ b/src/block_factory.c
@@ -37,7 +37,7 @@ int spawn_space_available(State* s) {
         int x = s->block->cells[i][0] + s->block->x;
         int y = s->block->cells[i][1] + s->block->y;
 
-        if (s->grid[x][y] != Empty) {
+        if (s->grid[x][y] != EMPTY) {
             return 0;
         }
     }
@@ -46,42 +46,42 @@ int spawn_space_available(State* s) {
 
 void spawn_I(Block* b) {
     memcpy(b->cells, I_Block, sizeof(I_Block));
-    b->color = Cyan;
+    b->color = CYAN;
     b->type = I;
 }
 
 void spawn_O(Block* b) {
     memcpy(b->cells, O_Block, sizeof(I_Block));
-    b->color = Yellow;
+    b->color = YELLOW;
     b->type = O;
 }
 
 void spawn_T(Block* b) {
     memcpy(b->cells, T_Block, sizeof(I_Block));
-    b->color = Purple;
+    b->color = PURPLE;
     b->type = T;
 }
 
 void spawn_Z(Block* b) {
     memcpy(b->cells, Z_Block, sizeof(I_Block));
-    b->color = Red;
+    b->color = RED;
     b->type = Z;
 }
 
 void spawn_S(Block* b) {
     memcpy(b->cells, S_Block, sizeof(I_Block));
-    b->color = Green;
+    b->color = GREEN;
     b->type = S;
 }
 
 void spawn_J(Block* b) {
     memcpy(b->cells, J_Block, sizeof(I_Block));
-    b->color = Blue;
+    b->color = BLUE;
     b->type = J;
 }
 
 void spawn_L(Block* b) {
     memcpy(b->cells, L_Block, sizeof(I_Block));
-    b->color = White;
+    b->color = WHITE;
     b->type = L;
 }

--- a/src/block_factory.c
+++ b/src/block_factory.c
@@ -45,43 +45,43 @@ int spawn_space_available(State* s) {
 }
 
 void spawn_I(Block* b) {
-    memcpy(b->cells, I_Block, sizeof(I_Block));
+    copy_cells(I, b->cells);
     b->color = CYAN;
     b->type = I;
 }
 
 void spawn_O(Block* b) {
-    memcpy(b->cells, O_Block, sizeof(I_Block));
+    copy_cells(O, b->cells);
     b->color = YELLOW;
     b->type = O;
 }
 
 void spawn_T(Block* b) {
-    memcpy(b->cells, T_Block, sizeof(I_Block));
+    copy_cells(T, b->cells);
     b->color = PURPLE;
     b->type = T;
 }
 
 void spawn_Z(Block* b) {
-    memcpy(b->cells, Z_Block, sizeof(I_Block));
+    copy_cells(Z, b->cells);
     b->color = RED;
     b->type = Z;
 }
 
 void spawn_S(Block* b) {
-    memcpy(b->cells, S_Block, sizeof(I_Block));
+    copy_cells(S, b->cells);
     b->color = GREEN;
     b->type = S;
 }
 
 void spawn_J(Block* b) {
-    memcpy(b->cells, J_Block, sizeof(I_Block));
+    copy_cells(J, b->cells);
     b->color = BLUE;
     b->type = J;
 }
 
 void spawn_L(Block* b) {
-    memcpy(b->cells, L_Block, sizeof(I_Block));
+    copy_cells(L, b->cells);
     b->color = WHITE;
     b->type = L;
 }

--- a/src/controller.c
+++ b/src/controller.c
@@ -31,7 +31,7 @@ int is_user_input() {
 }
 
 void act_on_user_input(
-    char user_input, 
+    char user_input,
     Movement* m,
     int* frame_counter) {
 
@@ -81,7 +81,7 @@ int move_block(State* s, Movement* m) {
         int x = s->block->cells[i][0] + s->block->x;
         int y = s->block->cells[i][1] + s->block->y;
 
-        s->grid[x][y] = Empty;
+        s->grid[x][y] = EMPTY;
     }
 
     // Flags
@@ -91,7 +91,7 @@ int move_block(State* s, Movement* m) {
     int can_rotate = 1;
 
     // Keep attempty to apply moves until no moves can be applied
-    while (applied_move) { 
+    while (applied_move) {
         applied_move = 0;
 
         // Try to move vertically
@@ -102,7 +102,7 @@ int move_block(State* s, Movement* m) {
                 int y = s->block->cells[i][1] + s->block->y;
 
                 // Conditions where move is invalid
-                if (!in_grid(x, y + m->y) || s->grid[x][y + m->y] != Empty) {
+                if (!in_grid(x, y + m->y) || s->grid[x][y + m->y] != EMPTY) {
                     can_move_vert = 0;
                     break;
                 }
@@ -122,7 +122,7 @@ int move_block(State* s, Movement* m) {
                 int y = s->block->cells[i][1] + s->block->y;
 
                 // Conditions where move is invalid
-                if (!in_grid(x + m->x, y) || s->grid[x + m->x][y] != Empty) {
+                if (!in_grid(x + m->x, y) || s->grid[x + m->x][y] != EMPTY) {
                     can_move_horiz = 0;
                     break;
                 }
@@ -140,6 +140,7 @@ int move_block(State* s, Movement* m) {
             switch (m->r) {
                 case LEFT: rotate_left(s->block); break;
                 case RIGHT: rotate_right(s->block); break;
+                default: break;
             }
 
             for (int i = 0; i < 4; i++) {
@@ -147,7 +148,7 @@ int move_block(State* s, Movement* m) {
                 int y = s->block->cells[i][1] + s->block->y;
 
                 // Conditions where move is invalid
-                if (!in_grid(x, y) || s->grid[x][y] != Empty) {
+                if (!in_grid(x, y) || s->grid[x][y] != EMPTY) {
                     can_rotate = 0;
                     break;
                 }
@@ -158,6 +159,7 @@ int move_block(State* s, Movement* m) {
                 switch (m->r) {
                     case LEFT: rotate_right(s->block); break;
                     case RIGHT: rotate_left(s->block); break;
+                    default: break;
                 }
             } else {
                 m->r = NO_ROTATE;

--- a/src/controller.h
+++ b/src/controller.h
@@ -37,7 +37,7 @@ void act_on_user_input(char user_input, Movement* m, int* frame_counter);
 /*
  * Most basic movement in the game, attempt to move block down by one step. If
  * this movement is obstructed, return 0.
- * 
+ *
  * Moves have a set ordering in which they will be executed in the case that
  * some combination of movements is impossible.
  *  1: vertical move

--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,7 @@
 void initialize_grid(int grid[GRID_W][GRID_H]) {
     for (int x=0; x<GRID_W; x++) {
         for (int y=0; y<GRID_H; y++) {
-            grid[x][y] = Empty;
+            grid[x][y] = EMPTY;
         }
     }
 }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -9,13 +9,13 @@ void set_up_screen() {
     curs_set(false);
 
     // Set up color schemes for each block
-    init_pair(Cyan, COLOR_CYAN, COLOR_BLACK);
-    init_pair(Blue, COLOR_BLUE, COLOR_BLACK);
-    init_pair(White, COLOR_WHITE, COLOR_BLACK);
-    init_pair(Yellow, COLOR_YELLOW, COLOR_BLACK);
-    init_pair(Green, COLOR_GREEN, COLOR_BLACK);
-    init_pair(Purple, COLOR_MAGENTA, COLOR_BLACK);
-    init_pair(Red, COLOR_RED, COLOR_BLACK);
+    init_pair(CYAN, COLOR_CYAN, COLOR_BLACK);
+    init_pair(BLUE, COLOR_BLUE, COLOR_BLACK);
+    init_pair(WHITE, COLOR_WHITE, COLOR_BLACK);
+    init_pair(YELLOW, COLOR_YELLOW, COLOR_BLACK);
+    init_pair(GREEN, COLOR_GREEN, COLOR_BLACK);
+    init_pair(PURPLE, COLOR_MAGENTA, COLOR_BLACK);
+    init_pair(RED, COLOR_RED, COLOR_BLACK);
 }
 
 void display_grid(int grid[GRID_W][GRID_H]) {
@@ -24,7 +24,7 @@ void display_grid(int grid[GRID_W][GRID_H]) {
     for (int y = OFFSET; y < GRID_H; y++) {
         mvprintw(y-OFFSET, 0, "|");
         for (int x = 0; x < GRID_W; x++) {
-            if ((block = grid[x][y]) != Empty) {
+            if ((block = grid[x][y]) != EMPTY) {
                 attron(COLOR_PAIR(block));
                 printw("@");
                 attroff(COLOR_PAIR(block));

--- a/src/scorer.c
+++ b/src/scorer.c
@@ -8,7 +8,7 @@ void shift_rows_down(int grid[GRID_W][GRID_H]) {
         // to count how many times we need to shift populated
         // rows downwards
         for (c=0; c<GRID_W; c++) {
-            if (grid[c][r] != Empty) {
+            if (grid[c][r] != EMPTY) {
                 break;
             }
         }
@@ -21,7 +21,7 @@ void shift_rows_down(int grid[GRID_W][GRID_H]) {
             // beneath it, perform shift
             for (c=0; c<GRID_W; c++) {
                 grid[c][r+shift] = grid[c][r];
-                grid[c][r] = Empty;
+                grid[c][r] = EMPTY;
             }
         }
     }
@@ -29,7 +29,7 @@ void shift_rows_down(int grid[GRID_W][GRID_H]) {
 
 int is_empty(int grid[GRID_W][GRID_H]) {
     for (int i=0; i<GRID_W; i++) {
-        if (grid[i][GRID_H-1] != Empty) {
+        if (grid[i][GRID_H-1] != EMPTY) {
             return 0;
         }
     }
@@ -60,7 +60,7 @@ void score_rows(State* s, int rows_cleared) {
 
 void clear_row(int r, State* s) {
     for (int c=0; c<GRID_W; c++) {
-        s->grid[c][r] = Empty;
+        s->grid[c][r] = EMPTY;
     }
 }
 
@@ -73,7 +73,7 @@ void clear_rows(State* s) {
         // for each row that the block occupies
         r = s->block->y + s->block->cells[i][1];
         for (c=0; c<GRID_W; c++) {
-            if (s->grid[c][r] == Empty) {
+            if (s->grid[c][r] == EMPTY) {
                 break;
             }
         }

--- a/src/utils.c
+++ b/src/utils.c
@@ -13,5 +13,5 @@ const int rotation_matrix_L[2][2] = {{0,1}, {-1,0}};
 
 int in_grid(int x, int y) {
     if (x < 0 || x >= GRID_W || y < 0 || y >= GRID_H) return 0;
-    return 1; 
+    return 1;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,8 +8,8 @@ const int Z_Block[4][2] = {{0,0}, {1,0}, {0,-1}, {-1,-1}};
 const int S_Block[4][2] = {{0,0}, {-1,0}, {0,-1}, {1,-1}};
 const int J_Block[4][2] = {{0,0}, {1,0}, {-1,0}, {-1,-1}};
 const int L_Block[4][2] = {{0,0}, {-1,0}, {1,0}, {1,-1}};
-const int rotation_matrix_R[2][2] = {{0,-1}, {1,0}};
-const int rotation_matrix_L[2][2] = {{0,1}, {-1,0}};
+const int rotation_matrix_L[2][2] = {{0,-1}, {1,0}};
+const int rotation_matrix_R[2][2] = {{0,1}, {-1,0}};
 
 int in_grid(int x, int y) {
     if (x < 0 || x >= GRID_W || y < 0 || y >= GRID_H) return 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -43,7 +43,7 @@ int in_grid(int x, int y);
  *
  * Not defined as enum class to allow implicit casting to int
  */
-typedef enum {Empty, Cyan, Blue, White, Yellow, Green, Purple, Red} BlockColor;
+typedef enum {EMPTY, CYAN, BLUE, WHITE, YELLOW, GREEN, PURPLE, RED} BlockColor;
 
 /*
  * Taken from http://tetris.wikia.com/wiki/Tetromino


### PR DESCRIPTION
Right and left rotation matrices were swapped so "f" rotated ccw instead of cw.
Changed all `memcpy`s in blockfactory to use the `copy_cells` method