### PR TITLE
FIX: Score multiplier and preview "bug"

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -150,6 +150,8 @@ void render(State* state) {
 
     if (state->level < 5) {
         display_preview(row, state->next);
+    } else {
+        mvprintw(row++, MENU_COL, "NO PREVIEW AT LEVEL 5 AND ABOVE!");
     }
 }
 

--- a/src/scorer.c
+++ b/src/scorer.c
@@ -83,7 +83,7 @@ void score_rows(State* s, int rows_cleared) {
         multiplier += 2000;
     }
 
-    s->score += multiplier * (s->level);
+    s->score += multiplier * (s->level+1);
 }
 
 void clear_row(int r, State* s) {


### PR DESCRIPTION
Fixed the row clear score multiplier so that level 0 still gets
multiplier. Also clarified the "bug" of the preview block
disappearing at level 5 (it is actually disabled). Now a message
appears explaining what happened.